### PR TITLE
replace `take_latest_token` with `Option::take`

### DIFF
--- a/saba_core/src/renderer/html/token.rs
+++ b/saba_core/src/renderer/html/token.rs
@@ -118,15 +118,6 @@ impl HtmlTokenizeStateMachine {
         }
     }
 
-    fn take_latest_token(&mut self) -> HtmlToken {
-        assert!(self.latest_token.is_some());
-        let token = self.latest_token.clone().unwrap();
-        self.latest_token = None;
-        assert!(self.latest_token.is_none());
-
-        token
-    }
-
     fn reconsume(&mut self) {
         assert!(self.pos > 0);
         self.pos -= 1;
@@ -347,7 +338,7 @@ impl HtmlTokenizeStateMachine {
                     }
                     Some('>') => {
                         self.state = State::Data;
-                        Some(vec![self.take_latest_token()])
+                        Some(vec![self.latest_token.take().unwrap()])
                     }
                     None => Some(vec![HtmlToken::Eof]),
                     Some(c) => {
@@ -363,7 +354,7 @@ impl HtmlTokenizeStateMachine {
                     Some('>') => {
                         self.set_self_closing_flag();
                         self.state = State::Data;
-                        Some(vec![self.take_latest_token()])
+                        Some(vec![self.latest_token.take().unwrap()])
                     }
                     _ => todo!(),
                 }
@@ -472,7 +463,7 @@ impl HtmlTokenizeStateMachine {
                     }
                     Some('>') => {
                         self.state = State::Data;
-                        Some(vec![self.take_latest_token()])
+                        Some(vec![self.latest_token.take().unwrap()])
                     }
                     None => Some(vec![HtmlToken::Eof]),
                     Some(c) => {
@@ -494,7 +485,7 @@ impl HtmlTokenizeStateMachine {
                     }
                     Some('>') => {
                         self.state = State::Data;
-                        Some(vec![self.take_latest_token()])
+                        Some(vec![self.latest_token.take().unwrap()])
                     }
                     None => Some(vec![HtmlToken::Eof]),
                     Some(_) => {
@@ -540,9 +531,9 @@ impl HtmlTokenizeStateMachine {
                 match c {
                     Some('>') => {
                         self.state = State::Data;
-                        Some(vec![self.take_latest_token()])
+                        Some(vec![self.latest_token.take().unwrap()])
                     }
-                    None => Some(vec![self.take_latest_token(), HtmlToken::Eof]),
+                    None => Some(vec![self.latest_token.take().unwrap(), HtmlToken::Eof]),
                     Some(c) => {
                         self.append_doctype_name(c);
                         None


### PR DESCRIPTION
The function `take_latest_token`

https://github.com/pizzacat83/sabatora/blob/0a0c76f7eae2fd51a1901f9d82c52f934f2b78e6/saba_core/src/renderer/html/token.rs#L121-L128

looks almost identical to [`Option::take`](https://doc.rust-lang.org/std/option/enum.Option.html#method.take)

> Takes the value out of the option, leaving a `None` in its place.

so I replaced your function with the one from the standard library. (side effect: `.clone()` was removed!)

Feel free to close this PR as this change has not been discussed at all.